### PR TITLE
Added "print" command to print a templates value to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ that is passed to stencil contains a combination of:
 
 To use from Leiningen add to `project.clj`:
 ```clojure
-:plugins [ [lein-resource "15.10.1"] ] 
+:plugins [ [lein-resource "15.10.2"] ] 
 ```
 To have it run before the jar file creation:
 ```clojure
@@ -59,6 +59,13 @@ To run to plugin directly simply enter
 To see all the properties that are passed to stencil:
 
     lein resource pprint
+
+
+To print the value of a stencil passed as an argument (useful for build scripts & testing templates)
+
+     lein resource print  "{{version}}"
+     export MY_PROJECT_VERSION=$(lein resource print "{{name}}:{{version}}")
+
 
 To delete all the copied files and empty directories:
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 
-(defproject lein-resource "15.10.1" 
+(defproject lein-resource "15.10.2" 
   :description 
   "
 A task that copies the files for the resource-paths to the
@@ -20,6 +20,12 @@ Remove the files created by the plugin.
 
      lein resource clean 
 
+
+###  Print
+Print the value of a stencil specified as an argument, useful for build scripts
+
+     lein resource print  \"{{version}}\"
+     export MY_PROJECT_VERSION=$(lein resource print \"{{name}}:{{version}}\")
 
 ### Pretty Print
 Dump the map of values sent to stencil.

--- a/src/leiningen/resource.clj
+++ b/src/leiningen/resource.clj
@@ -217,15 +217,19 @@ Return a FileSpec"
                         (verbose-msg project-info "file-spec-seq")
                         (map (partial copy-file-spec project-info)))))
 
+(defn print-task [value-map patterns]
+  (doseq [patt patterns]
+    (println (stencil/render-string patt value-map))))
+
 ;; ## resource
-;; This is the main entry point into the plugin.  It supports 3 tasks:
-;; copy, clean and pprint.
+;; This is the main entry point into the plugin.  It supports 4 tasks:
+;; copy, clean, print and pprint.
 ;;
 ;; This function creates the `ProjectInfo`, determines which task is
 ;; needs and calls it.
 
 (defn resource
-  "Task name can also be pprint or clean"
+  "Task name can also be print, pprint or clean"
   [project & task-keys]
   (stencil.loader/set-cache {})
   (let [{:keys [resource-paths target-path extra-values excludes includes 
@@ -245,11 +249,12 @@ Return a FileSpec"
           project-info (ProjectInfo. resource-paths target-path value-map includes excludes skip-stencil update silent verbose)]
       (verbose-msg project-info "project-info" project-info)
       ;;(println "TASK:" task-name)
-      (cond
-       (= "pprint" task-name) (pprint value-map)
-       (= "clean" task-name) (clean-task project-info)
-       (= "copy" task-name) (copy-task project-info)
-       :else (copy-task project-info)))))
+      (condp = task-name
+       "print" (print-task value-map (rest task-keys))
+       "pprint" (pprint value-map)
+       "clean" (clean-task project-info)
+       "copy" (copy-task project-info)
+       (copy-task project-info)))))
 
 (defn compile-hook [task & [project & more-args :as args]]
   (msg (:silent project) "Copying resources...")

--- a/test/plugin/test/core.clj
+++ b/test/plugin/test/core.clj
@@ -29,3 +29,9 @@
 (deftest test-pprint
   (let [^String r (with-out-str (resource project "pprint"))]
     (is (.contains r (str mykey)))))
+
+(deftest test-print
+  (let [out-str (with-out-str (resource project "print" "{{resource.target-path}}={{resource.extra-values.key}}"))
+        expected (str (get-in project [:resource :target-path]) "="
+                      (get-in project [:resource :extra-values mykey]) "\n")]
+    (is (= expected out-str))))


### PR DESCRIPTION
I've added a simple additional command "print" that accepts one or more templates on the command line and prints the value. It's useful for build scripts and allows you to keep templated files and other artefacts in sync.

For example to move a  docker latest to to the last build in bash you could use:

PRJ_NAME=$(lein resource print "{{name}}")
PRJ_VERSION=$(lein resource print "{{version}}")
docker tag -f "${PRJ_NAME}:${PRJ_VERSION}" "${PRJ_NAME}:latest"