### PR TITLE
Fix Leiningen plugin version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ that is passed to stencil contains a combination of:
 
 ## Usage
 
-To use from Leiningen add to `project.clj`:
-```clojure
-:plugins [ [lein-resource "16.9.1"] ] 
-```
+To use from Leiningen add this project to the `:plugins` vector in your `project.clj`:
+
+[![Current version](https://img.shields.io/clojars/v/lein-resource.svg)](http://clojars.org/lein-resource)
+
 To have it run before the jar file creation:
 ```clojure
 :prep-tasks ["javac" "compile" "resource"]


### PR DESCRIPTION
I just wasted an hour or two trying to figure out why I could not get per-resource-path extra values working, only to eventually realize after studying the source code that the problem is that the README says to use an old version that doesn’t include the feature, even though the feature is documented on the same page. This change updates the version to one that is dynamic, based on the latest version found in clojars, so it can’t be forgotten like this in the future.
